### PR TITLE
fixing backup user flow

### DIFF
--- a/video_scoring/settings/base_settings.py
+++ b/video_scoring/settings/base_settings.py
@@ -602,20 +602,6 @@ class ProjectSettings(AbstSettings):
                 backup_location,
                 backup_file_name,
             )
-<<<<<<< Updated upstream
-            log.warning(f"Saving backup to {file}")
-            self.uid = uuid4()
-            self.file_location = file
-            self.name = f"{self.name} - Backup"
-            main_win.app_settings.app_crash.version = main_win.app_settings.version
-            main_win.app_settings.app_crash.project_locations.append(file)
-            main_win.app_settings.save()
-            try:
-                main_win.notify_wont_save()
-            except Exception as e:
-                log.error(f"Error notifying user of crash: {e}")
-=======
->>>>>>> Stashed changes
         if not os.path.exists(os.path.dirname(self.file_location)):
             os.makedirs(os.path.dirname(self.file_location))
         try:
@@ -649,15 +635,7 @@ class ProjectSettings(AbstSettings):
                 level="info",
             )
         except Exception as e:
-<<<<<<< Updated upstream
             log.error(f"Error dumping project settings: {e}")
-            # propagate the error
-=======
-            log.warn(f"Error dumping project settings: {e}")
-            # log full traceback
-            import traceback
-            log.warn(traceback.format_exc(limit=20))
->>>>>>> Stashed changes
             raise e
 
 

--- a/video_scoring/settings/base_settings.py
+++ b/video_scoring/settings/base_settings.py
@@ -3,7 +3,6 @@ import json
 import logging
 import os
 import zipfile
-from re import A
 from typing import (TYPE_CHECKING, Any, Dict, List, Literal, Tuple, TypeVar,
                     Union)
 from uuid import UUID, uuid4
@@ -580,20 +579,30 @@ class ProjectSettings(AbstSettings):
                 },
             )
 
-    def save(self, main_win: "MainWindow", file=None):
-        if file:
+    def save(self, main_win: "MainWindow", file=None, ignore_backup=False):
+        backup_project = None
+        og_location = self.file_location
+        if file and file != self.file_location:
+            # this is like a new project, so we need to create a new uid
             self.uid = uuid4()
             self.file_location = file
         # get UNHANDLED_EXCEPTION environment variable
-        if os.environ.get("UNHANDLED_EXCEPTION", "False") == "True":
+        if os.environ.get("UNHANDLED_EXCEPTION", "False") == "True" and not ignore_backup:
             main_win.app_settings.app_crash = AppCrash(
                 project_uid=self.uid,
             )
+            backup_project = ProjectSettings()
             backup_location = os.path.join(user_data_dir(), "Backups")
-            file = os.path.join(
+            backup_file_name = f'{self.name} - Backup - {str(main_win.app_settings.app_crash.timestamp.strftime("%Y-%m-%d %H-%M-%S"))}.vsap'
+            if not os.path.exists(backup_location):
+                os.makedirs(backup_location, exist_ok=True)
+            if os.path.exists(os.path.join(backup_location, backup_file_name)):
+                backup_file_name = f'{self.name} - Backup - {str(main_win.app_settings.app_crash.timestamp.strftime("%Y-%m-%d %H-%M-%S"))} - {str(uuid4())}.vsap'
+            backup_project_file_location = os.path.join(
                 backup_location,
-                f"{str(uuid4())}_{self.name}_{str(main_win.app_settings.app_crash.timestamp.strftime('%Y-%m-%d_%H-%M-%S'))}.vsap",
+                backup_file_name,
             )
+<<<<<<< Updated upstream
             log.warning(f"Saving backup to {file}")
             self.uid = uuid4()
             self.file_location = file
@@ -605,23 +614,51 @@ class ProjectSettings(AbstSettings):
                 main_win.notify_wont_save()
             except Exception as e:
                 log.error(f"Error notifying user of crash: {e}")
+=======
+>>>>>>> Stashed changes
         if not os.path.exists(os.path.dirname(self.file_location)):
             os.makedirs(os.path.dirname(self.file_location))
         try:
-            # set the modified date
+            # if there is a backup project, save the project there before writing the current changes
+            if backup_project:
+                try:
+                    backup_project.load_from_file(og_location)
+                    backup_project.uid = uuid4()
+                    backup_project.name = backup_file_name
+                    backup_project.file_location = backup_project_file_location
+                    backup_project.save(main_win=main_win, ignore_backup=True)
+                    log.warning(f"Saving backup to {backup_project_file_location}")
+                    main_win.app_settings.app_crash.version = main_win.app_settings.version
+                    main_win.app_settings.app_crash.project_locations.append(backup_project_file_location)
+                    main_win.app_settings.save()
+                except Exception as e:
+                    # if we can't save the backup, set save the current changes to the backup so that we don't overwrite anything, and notify the user
+                    log.error(f"Error saving backup: {e}")
+                    self.uid = uuid4()
+                    self.file_location = backup_project_file_location
+                    self.name = backup_project.name
+                    main_win.notify_wont_save(location = backup_project_file_location)
+
             self.modified = datetime.datetime.now()
             dump = json.dumps(self.model_dump(), indent=4, cls=SettingsEncoder)
+            with zipfile.ZipFile(self.file_location, "w") as zipf:
+                zipf.writestr("settings.json", dump)
+            sentry_sdk.add_breadcrumb(
+                category="project_settings",
+                message=f"saved project_settings file: {str(self.uid)} - {self.name}",
+                level="info",
+            )
         except Exception as e:
+<<<<<<< Updated upstream
             log.error(f"Error dumping project settings: {e}")
             # propagate the error
+=======
+            log.warn(f"Error dumping project settings: {e}")
+            # log full traceback
+            import traceback
+            log.warn(traceback.format_exc(limit=20))
+>>>>>>> Stashed changes
             raise e
-        with zipfile.ZipFile(self.file_location, "w") as zipf:
-            zipf.writestr("settings.json", dump)
-        sentry_sdk.add_breadcrumb(
-            category="project_settings",
-            message=f"saved project_settings file: {str(self.uid)} - {self.name}",
-            level="info",
-        )
 
 
 class ApplicationSettings(AbstSettings):

--- a/video_scoring/settings/settings.py
+++ b/video_scoring/settings/settings.py
@@ -57,8 +57,6 @@ class Settings:
             log.info(
                 f"Loaded application settings version: {self.app_settings.version}"
             )
-        if self.app_settings.app_crash is not None:
-            self.main_win.loaded.connect(self.main_win.notify_last_crash)
 
     def save_app_settings_file(self):
         save_loc = self.app_settings.save()
@@ -68,7 +66,9 @@ class Settings:
         self, old_settings: dict, new_name: str, new_location: str
     ):
         from video_scoring.settings.base_settings import (
-            BehaviorTrackSetting, OOBehaviorItemSetting)
+            BehaviorTrackSetting,
+            OOBehaviorItemSetting,
+        )
 
         # a new project will be created for the old monolithic settings
         project = ProjectSettings()

--- a/video_scoring/video_scoring.py
+++ b/video_scoring/video_scoring.py
@@ -1,5 +1,4 @@
 import base64
-import dis
 import inspect
 import json
 import logging
@@ -15,9 +14,13 @@ from qtpy.QtCore import QThread, QUrl, Signal
 from qtpy.QtWidgets import QMainWindow, QSplashScreen
 
 from video_scoring.command_stack import CommandStack
-from video_scoring.settings import (DockWidgetState, Layout, ProjectSettings,
-                                    Settings, TDTData)
-from video_scoring.widgets.analysis import VideoAnalysisDock
+from video_scoring.settings import (
+    DockWidgetState,
+    Layout,
+    ProjectSettings,
+    Settings,
+    TDTData,
+)
 from video_scoring.widgets.loaders import TDTLoader
 from video_scoring.widgets.progress import ProgressBar, ProgressSignals
 from video_scoring.widgets.projects import ProjectsWidget
@@ -26,9 +29,14 @@ from video_scoring.widgets.settings import SettingsDockWidget
 from video_scoring.widgets.style_sheet import DynamicIcon, StyleSheet
 from video_scoring.widgets.timeline import TimelineDockWidget
 from video_scoring.widgets.timestamps import TimeStampsDockwidget
-from video_scoring.widgets.update import (UpdateCheck, UpdatedDialog,
-                                          UpdateDialog, Updater)
+from video_scoring.widgets.update import (
+    UpdateCheck,
+    UpdatedDialog,
+    UpdateDialog,
+    Updater,
+)
 from video_scoring.widgets.video.frontend import VideoPlayerDockWidget
+from video_scoring.utils import user_data_dir
 
 log = logging.getLogger("video_scoring")
 
@@ -194,7 +202,7 @@ class MainWindow(QMainWindow):
         self.set_central_widget(self.projects_w)
         self.projects_w.import_project()
 
-    def import_previous_project(self):
+    def import_old_project(self):
         # prompt file dialog to get json
         file_dialog = QtWidgets.QFileDialog()
         file_dialog.setFileMode(QtWidgets.QFileDialog.FileMode.AnyFile)
@@ -273,8 +281,6 @@ class MainWindow(QMainWindow):
     def no_update_available(self):
         # check the installer folder in the appdata Video Scoring folder
         # if it exists, check if the version is the same as the current version, if so delete it
-        from video_scoring.settings.base_settings import user_data_dir
-
         installer_dir = os.path.join(os.path.dirname(user_data_dir()), "installer")
         if os.path.exists(installer_dir):
             for file in os.listdir(installer_dir):
@@ -403,11 +409,10 @@ class MainWindow(QMainWindow):
         self.file_menu.addAction("New Project", self.new_project)
         self.file_menu.addAction("Open Project", self.open_project)
         self.file_menu.addAction("Import Project", self.import_project_file)
-        self.file_menu.addAction(
-            "Import Previous Project", self.import_previous_project
-        )
+        self.file_menu.addAction("Import Old Project", self.import_old_project)
         self.file_menu.addAction("Save Project", self.save_settings)
         self.file_menu.addAction("Save Project As", self.save_project_as)
+        self.file_menu.addAction("Open Backups", self.open_backups)
         self.file_menu.addSeparator()
         self.import_menu = self.file_menu.addMenu("Import")
         if self.import_menu is None:
@@ -469,7 +474,8 @@ class MainWindow(QMainWindow):
                             "New Project",
                             "Open Project",
                             "Import Project",
-                            "Import Previous Project",
+                            "Import Old Project",
+                            "Open Backups",
                             "Exit",
                         ]:
                             sub_action.setEnabled(True)
@@ -597,10 +603,14 @@ class MainWindow(QMainWindow):
         # if the main window is outside of the visible screen, move it to the center
         if not self.is_pos_visible((self.x(), self.y())):
             self.move(
-                int(QtWidgets.QApplication.screens()[0].geometry().width() / 2
-                - self.width() / 2),
-                int(QtWidgets.QApplication.screens()[0].geometry().height() / 2
-                - self.height() / 2),
+                int(
+                    QtWidgets.QApplication.screens()[0].geometry().width() / 2
+                    - self.width() / 2
+                ),
+                int(
+                    QtWidgets.QApplication.screens()[0].geometry().height() / 2
+                    - self.height() / 2
+                ),
             )
 
         self.restoreState(base64.b64decode(layout.dock_state), 1)
@@ -687,8 +697,7 @@ class MainWindow(QMainWindow):
     def import_timestamps(self):
         # try save current project
         self.save_settings()
-        from video_scoring.widgets.timestamps.importer import \
-            TimestampsImporter
+        from video_scoring.widgets.timestamps.importer import TimestampsImporter
 
         self.ts_importer = TimestampsImporter(self)
         self.ts_importer.imported.connect(
@@ -916,6 +925,13 @@ class MainWindow(QMainWindow):
         self.projects_w = ProjectsWidget(self)
         self.set_central_widget(self.projects_w)
 
+    def open_backups(self):
+        # open the backups folder with the os file explorer
+        backup_location = os.path.join(user_data_dir(), "Backups")
+        if not os.path.exists(backup_location):
+            os.makedirs(backup_location)
+        os.startfile(backup_location)
+
     def init_logging(self):
         self.log = logging.getLogger("video_scoring")
         self.update_log_file()
@@ -975,41 +991,19 @@ class MainWindow(QMainWindow):
             self.save_settings(file_dialog.selectedFiles()[0])
             self.projects_w.open_project_file(file_dialog.selectedFiles()[0])
 
-    def notify_wont_save(self):
+    def notify_wont_save(self, location: str):
         if self.app_settings.app_crash is None:
             return
         msg = QtWidgets.QMessageBox()
         msg.setWindowTitle("Something went wrong")
         msg.setText(
-            f"""There was an error with application. 
+            f"""There was an error with application. The original project file was not overwritten.
 
-The current project has NOT BEEN OVERWRITTEN with any changes. 
-
-Instead a backup with the current changes was saved at {self.app_settings.app_crash.project_locations[0]}.
-
-The developers have been notified of this error and will work to fix it as soon as possible. If you would like to help, please submit a bug report https://github.com/DannyAlas/qt-vid-score/issues
+Instead the project changes were saved at {location}.
 """
         )
         msg.setIcon(QtWidgets.QMessageBox.Icon.Critical)
         msg.exec()
-
-    def notify_last_crash(self):
-        if self.settings.app_settings.app_crash is None:
-            return
-        msg = QtWidgets.QMessageBox()
-        msg.setWindowTitle("Unexpected Exit")
-        msg.setText(
-            f"""The application unexpectedly exited.
-
-Your project was saved at {self.settings.app_settings.app_crash.project_locations[0]}.
-"""
-        )
-        msg.setIcon(QtWidgets.QMessageBox.Icon.Critical)
-        msg.exec()
-        self.projects_w.add_backup_project_file(
-            self.settings.app_settings.app_crash.project_locations[0]
-        )
-        self.settings.app_settings.app_crash = None
 
     def update_log_file(self):
         if self.settings.app_settings is None:


### PR DESCRIPTION
Backups flow now will first try to make a backup of the file that's about to be overwritten before writing changes to the file. The user can open the backups folder with a menu to load a backup if there is an issue with the writes. TODO: add a rotation for backups not to fill the backups folder.

fixes #27 